### PR TITLE
☠️ #48 기존 +1씩 올라가던 playlistId 삭제

### DIFF
--- a/src/api/playlist/createPlayList.ts
+++ b/src/api/playlist/createPlayList.ts
@@ -1,5 +1,5 @@
 import { auth, db } from '@/firebase/firebaseConfig'
-import { doc, addDoc, getDocs, getDoc, collection } from 'firebase/firestore'
+import { doc, addDoc, getDoc, collection } from 'firebase/firestore'
 
 export interface videoListProps {
   title: string
@@ -23,13 +23,8 @@ export const createPlayList = async (
       const userName = userDoc.exists() ? userDoc.data().name : 'Unknown User'
 
       const playlistCollectionRef = collection(db, 'PLAYLISTS')
-      const playlistsSnapshot = await getDocs(playlistCollectionRef)
-      const playlistCount = playlistsSnapshot.size
-
-      const playlistId = playlistCount + 1
 
       const newPlaylistRef = await addDoc(playlistCollectionRef, {
-        playlistId: playlistId,
         title: title,
         tags: tags,
         createdAt: new Date(),


### PR DESCRIPTION
## 📋 풀리퀘스트 관련 코멘트 

플레이리스트 추가 시 문서 -> 필드에 생성되던 playlistId값을 삭제했습니다.
플레이리스트 추가할 때 생성되는 문서의 값이 해시값 형태로 고유하게 생성되기 때문에 문서의 id를 playlistId로 사용하시면 될 것 같습니다.



![image](https://github.com/user-attachments/assets/1e4a1142-1ae1-4bab-be03-c7addfbb2003)

<!-- Generated by sourcery-ai[bot]: start summary -->

## Sourcery에 의한 요약

플레이리스트 생성 시 수동으로 playlistId를 증가시키는 것을 제거하고, 식별을 위해 문서의 고유 해시 값을 사용합니다.

개선 사항:
- 플레이리스트 생성 과정에서 증가하는 playlistId 필드를 제거하고, 대신 문서의 고유 해시 값을 식별자로 사용합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Eliminate the manual increment of playlistId during playlist creation and rely on the document's unique hash value for identification.

Enhancements:
- Remove the incremental playlistId field from the playlist creation process, utilizing the document's unique hash value as the identifier instead.

</details>

<!-- Generated by sourcery-ai[bot]: end summary -->