### PR TITLE
Fix/profile

### DIFF
--- a/src/api/playlist/getPlayList.ts
+++ b/src/api/playlist/getPlayList.ts
@@ -3,11 +3,11 @@ import { collection, getDocs, getDoc, query, where, doc } from 'firebase/firesto
 import { showplaylistProps, videoListProps } from '@/types/playlistType'
 import formatDate from '@/utils/formatDate'
 
-export const getPlayList = async () => {
+export const getPlayList = async (userId: string | undefined) => {
   try {
-    const user = auth.currentUser
-    if (user) {
-      const uid = user.uid
+    const uid = userId || auth.currentUser?.uid
+
+    if (uid) {
       const playlistRef = collection(db, 'PLAYLISTS')
       const q = query(playlistRef, where('author', '==', `/USERS/${uid}`))
       const querySnapShot = await getDocs(q)
@@ -30,7 +30,6 @@ export const getPlayList = async () => {
           thumbnail: thumbnail || 'not valid thumbnail',
         })
       }
-
       return playlists
     }
   } catch (error) {

--- a/src/api/playlist/getPlayList.ts
+++ b/src/api/playlist/getPlayList.ts
@@ -3,7 +3,7 @@ import { collection, getDocs, getDoc, query, where, doc } from 'firebase/firesto
 import { showplaylistProps, videoListProps } from '@/types/playlistType'
 import formatDate from '@/utils/formatDate'
 
-export const getPlayList = async (userId: string | undefined) => {
+export const getPlayList = async (userId?: string) => {
   try {
     const uid = userId || auth.currentUser?.uid
 

--- a/src/api/profile/profileInfo.ts
+++ b/src/api/profile/profileInfo.ts
@@ -17,13 +17,12 @@ export interface FollowingProps {
   img: string | null
 }
 
-export const userInfo = async () => {
+export const userInfo = async (uid?: string) => {
   try {
-    const user = auth.currentUser
+    const user = uid ? { uid } : auth.currentUser
 
-    if (user) {
-      const uid = user.uid
-      const userRef = doc(db, 'USERS', uid)
+    if (user && user.uid) {
+      const userRef = doc(db, 'USERS', user.uid)
       const userDoc = await getDoc(userRef)
 
       if (!userDoc.exists()) {
@@ -35,7 +34,7 @@ export const userInfo = async () => {
       const [followerSnapShot, followingSnapShot, querySnapShot] = await Promise.all([
         getDocs(collection(userRef, 'Followers')),
         getDocs(collection(userRef, 'Followings')),
-        getDocs(query(collection(db, 'PLAYLISTS'), where('author', '==', `/USERS/${uid}`))),
+        getDocs(query(collection(db, 'PLAYLISTS'), where('author', '==', `/USERS/${user.uid}`))),
       ])
 
       const followerLength = followerSnapShot.size

--- a/src/hooks/usePlaylistData.ts
+++ b/src/hooks/usePlaylistData.ts
@@ -1,19 +1,31 @@
 import { useEffect, useState } from 'react'
+import { auth } from '@/firebase/firebaseConfig'
+import { onAuthStateChanged } from 'firebase/auth'
 import { getPlayList } from '@/api/playlist/getPlayList'
 import { showplaylistProps } from '@/types/playlistType'
 
-export const usePlaylistData = () => {
+export const usePlaylistData = (userId?: string) => {
   const [playlistData, setPlayListData] = useState<showplaylistProps[]>([])
 
   useEffect(() => {
     const fetchPlayListData = async () => {
-      const data = await getPlayList()
+      const data = await getPlayList(userId)
       if (data) {
         setPlayListData(data)
       }
     }
-    fetchPlayListData()
-  }, [])
+
+    if (userId) {
+      fetchPlayListData()
+    } else {
+      const unsubscribe = onAuthStateChanged(auth, (user) => {
+        if (user) {
+          fetchPlayListData()
+        }
+      })
+      return () => unsubscribe()
+    }
+  }, [userId])
 
   return playlistData
 }

--- a/src/hooks/usePlaylistDetail.ts
+++ b/src/hooks/usePlaylistDetail.ts
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react'
 import { getPlayListDetails } from '@/api/playlist/getPlayList'
 import { videoListProps } from '@/types/playlistType'
 
-export const usePlaylistdetail = (playlistId: string | undefined) => {
+export const usePlaylistdetail = (playlistId?: string) => {
   const [videos, setVideos] = useState<videoListProps[]>([])
   const [selectedVideo, setSelectedVideo] = useState<videoListProps>()
   useEffect(() => {

--- a/src/hooks/useUserData.ts
+++ b/src/hooks/useUserData.ts
@@ -4,7 +4,7 @@ import { onAuthStateChanged } from 'firebase/auth'
 import { userInfo } from '@/api/profile/profileInfo'
 import Profile from '@/assets/profile_logo.jpg'
 
-export const useUserData = (userId: string | undefined) => {
+export const useUserData = (userId?: string) => {
   const [userData, setUserData] = useState({
     userName: '',
     userId: '',

--- a/src/hooks/useUserData.ts
+++ b/src/hooks/useUserData.ts
@@ -18,7 +18,7 @@ export const useUserData = (userId: string | undefined) => {
 
   useEffect(() => {
     const fetchUserData = async () => {
-      const data = await userInfo()
+      const data = await userInfo(userId)
       if (data) {
         setUserData({
           userName: data?.userName || '사용자',
@@ -33,12 +33,16 @@ export const useUserData = (userId: string | undefined) => {
       }
     }
 
-    const unsubscribe = onAuthStateChanged(auth, (user) => {
-      if (user) {
-        fetchUserData()
-      }
-    })
-    return () => unsubscribe()
+    if (userId) {
+      fetchUserData()
+    } else {
+      const unsubscribe = onAuthStateChanged(auth, (user) => {
+        if (user) {
+          fetchUserData()
+        }
+      })
+      return () => unsubscribe()
+    }
   }, [userId])
 
   return userData

--- a/src/pages/ProfilePage.tsx
+++ b/src/pages/ProfilePage.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled'
-import { Link, useParams, Outlet } from 'react-router-dom'
+import { Link, useParams } from 'react-router-dom'
 import { PATH } from '@/constants/path'
 import { fontSize, fontWeight } from '@/constants/font'
 import Button from '@/components/common/Button/Button'
@@ -10,9 +10,9 @@ import { useUserData } from '@/hooks/useUserData'
 import { usePlaylistData } from '@/hooks/usePlaylistData'
 
 const ProfilePage = () => {
-  const { userId } = useParams()
+  const { userId } = useParams<{ userId?: string }>()
   const userData = useUserData(userId)
-  const playlistData = usePlaylistData()
+  const playlistData = usePlaylistData(userId)
   const isMyProfile = !userId || userId === userData.userId
 
   const handleAllLists = () => {}
@@ -20,7 +20,6 @@ const ProfilePage = () => {
   //const handlePublicLists = () => {}
 
   //const handlePrivateLists = () => {}
-
   return (
     <Container>
       <div className="section-head">


### PR DESCRIPTION
## 📋 풀리퀘스트 관련 코멘트 

새로고침 했을 때 목록 데이터를 못불러오던 이슈 수정했습니다.
그리고 프로필 페이지를 로그인한 사용자 기준으로 작업해둬서 다른 사람의 프로필을 확인할 수가 없더라구요..
데이터를 받아오는 로직에서 userID 를 받도록 수정하여
 profile/다른 사용자의uid 를 url에 입력했을 때  다른 사용자의 프로필을  확인할 수 있도록 수정했습니다.

 [skip sourcery] 

## 📸 스크린샷 (선택 사항)


https://github.com/user-attachments/assets/04758ce0-8a1f-41c8-a217-55ee0f5ed464



<!-- 수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부해 주세요.--!>
<br/>
