### PR TITLE
☠️ #34 전체,공개,비공개 버튼 클릭 시 해당되는 컨텐츠 렌더링

### DIFF
--- a/src/api/playlist/getPlayList.ts
+++ b/src/api/playlist/getPlayList.ts
@@ -28,6 +28,7 @@ export const getPlayList = async (userId?: string) => {
           playlistId: doc.id,
           title: playlistData.title || 'Untitled',
           thumbnail: thumbnail || 'not valid thumbnail',
+          isPrivate: playlistData.isPrivate,
         })
       }
       return playlists

--- a/src/pages/ProfilePage.tsx
+++ b/src/pages/ProfilePage.tsx
@@ -9,7 +9,7 @@ import { colors } from '@/constants/color'
 import Profile from '@/assets/profile_logo.jpg'
 import { useUserData } from '@/hooks/useUserData'
 import { usePlaylistData } from '@/hooks/usePlaylistData'
-import { filterPlaylist } from '@/types/playlistType'
+import { filterPlaylist, showplaylistProps } from '@/types/playlistType'
 
 const ProfilePage = () => {
   const { userId } = useParams<{ userId?: string }>()
@@ -22,12 +22,30 @@ const ProfilePage = () => {
     setFilter(newFilter)
   }
 
+  const filteredMap = {
+    all: () => true,
+    public: (playlistData: showplaylistProps) => !playlistData.isPrivate,
+    private: (playlistData: showplaylistProps) => playlistData.isPrivate,
+  }
+
   const filteredLists = playlistData.filter((playlistData) => {
-    if (!isMyProfile && playlistData.isPrivate) return false
-    if (filter == 'all') return true
-    if (filter === 'public') return !playlistData.isPrivate
-    if (filter === 'private') return playlistData.isPrivate
+    return !isMyProfile && playlistData.isPrivate ? false : filteredMap[filter](playlistData)
   })
+
+  const filterBtns = [
+    {
+      label: '전체',
+      value: 'all' as filterPlaylist,
+    },
+    {
+      label: '공개',
+      value: 'public' as filterPlaylist,
+    },
+    {
+      label: '비공개',
+      value: 'private' as filterPlaylist,
+    },
+  ]
 
   return (
     <Container>
@@ -66,15 +84,11 @@ const ProfilePage = () => {
         <div className="text-playlist">플레이리스트</div>
         {isMyProfile && (
           <div className="section-btn">
-            <Button size="small" onClick={() => handleFilterChange('all')}>
-              전체
-            </Button>
-            <Button size="small" onClick={() => handleFilterChange('public')}>
-              공개
-            </Button>
-            <Button size="small" onClick={() => handleFilterChange('private')}>
-              비공개
-            </Button>
+            {filterBtns.map((btn) => (
+              <Button key={btn.value} size="small" onClick={() => handleFilterChange(btn.value)}>
+                {btn.label}
+              </Button>
+            ))}
           </div>
         )}
         {filteredLists.map((playlist, idx) => (

--- a/src/pages/ProfilePage.tsx
+++ b/src/pages/ProfilePage.tsx
@@ -9,19 +9,21 @@ import { colors } from '@/constants/color'
 import Profile from '@/assets/profile_logo.jpg'
 import { useUserData } from '@/hooks/useUserData'
 import { usePlaylistData } from '@/hooks/usePlaylistData'
+import { filterPlaylist } from '@/types/playlistType'
 
 const ProfilePage = () => {
   const { userId } = useParams<{ userId?: string }>()
   const userData = useUserData(userId)
   const playlistData = usePlaylistData(userId)
   const isMyProfile = !userId || userId === userData.userId
-  const [filter, setFilter] = useState<'all' | 'public' | 'private'>('all')
+  const [filter, setFilter] = useState<filterPlaylist>('all')
 
-  const handleFilterChange = (newFilter: 'all' | 'public' | 'private') => {
+  const handleFilterChange = (newFilter: filterPlaylist) => {
     setFilter(newFilter)
   }
 
   const filteredLists = playlistData.filter((playlistData) => {
+    if (!isMyProfile && playlistData.isPrivate) return false
     if (filter == 'all') return true
     if (filter === 'public') return !playlistData.isPrivate
     if (filter === 'private') return playlistData.isPrivate

--- a/src/pages/ProfilePage.tsx
+++ b/src/pages/ProfilePage.tsx
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled'
+import { useState } from 'react'
 import { Link, useParams } from 'react-router-dom'
 import { PATH } from '@/constants/path'
 import { fontSize, fontWeight } from '@/constants/font'
@@ -14,12 +15,18 @@ const ProfilePage = () => {
   const userData = useUserData(userId)
   const playlistData = usePlaylistData(userId)
   const isMyProfile = !userId || userId === userData.userId
+  const [filter, setFilter] = useState<'all' | 'public' | 'private'>('all')
 
-  const handleAllLists = () => {}
+  const handleFilterChange = (newFilter: 'all' | 'public' | 'private') => {
+    setFilter(newFilter)
+  }
 
-  //const handlePublicLists = () => {}
+  const filteredLists = playlistData.filter((playlistData) => {
+    if (filter == 'all') return true
+    if (filter === 'public') return !playlistData.isPrivate
+    if (filter === 'private') return playlistData.isPrivate
+  })
 
-  //const handlePrivateLists = () => {}
   return (
     <Container>
       <div className="section-head">
@@ -57,21 +64,28 @@ const ProfilePage = () => {
         <div className="text-playlist">플레이리스트</div>
         {isMyProfile && (
           <div className="section-btn">
-            <Button size="small" onClick={handleAllLists}>
+            <Button size="small" onClick={() => handleFilterChange('all')}>
               전체
             </Button>
-            <Button size="small">공개</Button>
-            <Button size="small">비공개</Button>
+            <Button size="small" onClick={() => handleFilterChange('public')}>
+              공개
+            </Button>
+            <Button size="small" onClick={() => handleFilterChange('private')}>
+              비공개
+            </Button>
           </div>
         )}
-        {playlistData.map((playlist, idx) => (
+        {filteredLists.map((playlist, idx) => (
           <div className="title-playlist" key={idx}>
             <div className="title-thumbnail">
               <Link to={`/playlist/${playlist.playlistId}`}>
                 <img src={playlist.thumbnail} alt={playlist.title} />
               </Link>
             </div>
-            <div className="title-video">{playlist.title}</div>
+            <div className="title-video">
+              {playlist.title}
+              {playlist.isPrivate && <div className="tag-private">비공개</div>}
+            </div>
           </div>
         ))}
       </div>
@@ -157,6 +171,13 @@ const Container = styled.div`
     display: flex;
     align-items: center;
     gap: 10px;
+
+    .tag-private {
+      background-color: ${colors.lightPurPle};
+      width: 54px;
+      border-radius: 15px;
+      text-align: center;
+    }
   }
 
   .title-thumbnail {

--- a/src/types/playlistType.d.ts
+++ b/src/types/playlistType.d.ts
@@ -15,3 +15,5 @@ export interface videoListProps extends showplaylistProps {
   playlistTitle?: string
   likes?: number
 }
+
+export type filterPlaylist = 'all' | 'public' | 'private'

--- a/src/types/playlistType.d.ts
+++ b/src/types/playlistType.d.ts
@@ -1,5 +1,6 @@
 export interface showplaylistProps {
   playlistId?: string
+  isPrivate?: boolean
   title: string
   thumbnail: string
 }


### PR DESCRIPTION
## 📋 풀리퀘스트 관련 코멘트 

로그인 한 사용자의 프로필에서 전체. 공개, 비공개 버튼 클릭 시 해당되는 컨텐츠 목록이 렌더링 되도록 수정했습니다.
url을 통해 profile/다른사용자uid로 접속하시면 다른 사용자 프로필에서는 공개로 올린 플리 목록들만 렌더링 되는 것을 확인하실 수 있습니다~!~!

active 상태는 기능 구현이 끝난 후 제가 추가해두도록 하겠습니다


## 📸 스크린샷 (선택 사항)

https://github.com/user-attachments/assets/e72568fe-05c5-414c-ad79-5aee0c4e691e


