### PR TITLE
☠️ #55 Link 컴포넌트 사용시 DOM요소로 불필요한 props 전달 문제 해결

### DIFF
--- a/src/components/common/Button/Button.tsx
+++ b/src/components/common/Button/Button.tsx
@@ -1,4 +1,4 @@
-import { FC, ReactNode } from 'react'
+import { CSSProperties, FC, ReactNode } from 'react'
 import { css } from '@emotion/react'
 import styled from '@emotion/styled'
 import { colors } from '@/constants/color'
@@ -7,16 +7,18 @@ import { fontSize, fontWeight } from '@/constants/font'
 type ButtonSize = 'small' | 'normal'
 type ButtonVariant = 'primary' | 'secondary' | 'outline' | 'text'
 
-export interface IButtonProps {
+export interface ButtonProps {
   children: ReactNode
   onClick?: (event: React.MouseEvent<HTMLButtonElement>) => void
   size?: ButtonSize
   variant?: ButtonVariant
-  buttonWidth?: string
+  buttonWidth?: CSSProperties['width']
   disabled?: boolean
 }
 
-const Button: FC<IButtonProps> = ({
+type ButtonComponentProps = Pick<ButtonProps, 'size' | 'variant' | 'buttonWidth' | 'disabled'>
+
+const Button: FC<ButtonProps> = ({
   children,
   onClick,
   size = 'normal',
@@ -85,21 +87,16 @@ const sizeStyles = {
   },
 }
 
-const ButtonComponent = styled.button<{
-  size: ButtonSize
-  variant: ButtonVariant
-  buttonWidth?: string
-  disabled?: boolean
-}>`
+const ButtonComponent = styled.button<ButtonComponentProps>`
   ${baseStyles};
   width: ${({ buttonWidth }) => buttonWidth};
-  height: ${({ size }) => sizeStyles[size].height};
-  padding: ${({ size }) => sizeStyles[size].padding};
-  background-color: ${({ variant }) => themeColors[variant]};
-  color: ${({ variant }) => themeTextColors[variant]};
+  height: ${({ size = 'normal' }) => sizeStyles[size].height};
+  padding: ${({ size = 'normal' }) => sizeStyles[size].padding};
+  background-color: ${({ variant = 'primary' }) => themeColors[variant]};
+  color: ${({ variant = 'primary' }) => themeTextColors[variant]};
   border: ${({ variant }) => (variant === 'outline' ? `1px solid ${colors.black}` : 'none')};
   font-weight: ${({ variant }) => (variant === 'primary' ? fontWeight.bold : fontWeight.medium)};
-  font-size: ${({ size }) => sizeStyles[size].fontSize};
+  font-size: ${({ size = 'normal' }) => sizeStyles[size].fontSize};
   transition:
     background-color 0.2s ease,
     color 0.2s ease;
@@ -111,7 +108,7 @@ const ButtonComponent = styled.button<{
       `
       color: ${themeHoverColors.text};
     `}
-    ${({ variant, disabled }) =>
+    ${({ variant = 'primary', disabled }) =>
       variant !== 'text' &&
       !disabled &&
       `

--- a/src/components/common/Button/ButtonLink.tsx
+++ b/src/components/common/Button/ButtonLink.tsx
@@ -1,4 +1,4 @@
-import { FC, ReactNode } from 'react'
+import { CSSProperties, FC, ReactNode } from 'react'
 import { css } from '@emotion/react'
 import styled from '@emotion/styled'
 import { Link } from 'react-router-dom'
@@ -8,16 +8,21 @@ import { fontSize, fontWeight } from '@/constants/font'
 type ButtonSize = 'small' | 'normal'
 type ButtonVariant = 'primary' | 'secondary' | 'outline' | 'text'
 
-export interface IButtonLinkProps {
+export interface ButtonLinkProps {
   children: ReactNode
   to: string
   size?: ButtonSize
   variant?: ButtonVariant
-  buttonWidth?: string
+  buttonWidth?: CSSProperties['width']
   disabled?: boolean
 }
 
-const ButtonLink: FC<IButtonLinkProps> = ({
+type ButtonLinkComponentProps = Pick<
+  ButtonLinkProps,
+  'size' | 'variant' | 'buttonWidth' | 'disabled'
+>
+
+const ButtonLink: FC<ButtonLinkProps> = ({
   children,
   to,
   size = 'normal',
@@ -86,21 +91,19 @@ const sizeStyles = {
   },
 }
 
-const ButtonLinkComponent = styled(Link)<{
-  size: ButtonSize
-  variant: ButtonVariant
-  buttonWidth?: string
-  disabled?: boolean
-}>`
+const ButtonLinkComponent = styled(Link, {
+  shouldForwardProp: (prop) =>
+    prop !== 'size' && prop !== 'variant' && prop !== 'buttonWidth' && prop !== 'disabled',
+})<ButtonLinkComponentProps>`
   ${baseStyles};
   width: ${({ buttonWidth }) => buttonWidth};
-  height: ${({ size }) => sizeStyles[size].height};
-  padding: ${({ size }) => sizeStyles[size].padding};
-  background-color: ${({ variant }) => themeColors[variant]};
-  color: ${({ variant }) => themeTextColors[variant]};
+  height: ${({ size = 'normal' }) => sizeStyles[size].height};
+  padding: ${({ size = 'normal' }) => sizeStyles[size].padding};
+  background-color: ${({ variant = 'primary' }) => themeColors[variant]};
+  color: ${({ variant = 'primary' }) => themeTextColors[variant]};
   border: ${({ variant }) => (variant === 'outline' ? `1px solid ${colors.black}` : 'none')};
   font-weight: ${({ variant }) => (variant === 'primary' ? fontWeight.bold : fontWeight.medium)};
-  font-size: ${({ size }) => sizeStyles[size].fontSize};
+  font-size: ${({ size = 'normal' }) => sizeStyles[size].fontSize};
   transition:
     background-color 0.2s ease,
     color 0.2s ease;
@@ -112,7 +115,7 @@ const ButtonLinkComponent = styled(Link)<{
       `
       color: ${themeHoverColors.text};
     `}
-    ${({ variant, disabled }) =>
+    ${({ variant = 'primary', disabled }) =>
       variant !== 'text' &&
       !disabled &&
       `

--- a/src/components/common/Input/Input.tsx
+++ b/src/components/common/Input/Input.tsx
@@ -3,7 +3,7 @@ import styled from '@emotion/styled'
 import { colors } from '@/constants/color'
 import { CSSProperties } from 'react'
 
-export interface IInputProps {
+export interface InputProps {
   value: string
   onChange: (event: React.ChangeEvent<HTMLInputElement>) => void
   onKeyDown?: (event: React.KeyboardEvent) => void
@@ -15,8 +15,10 @@ export interface IInputProps {
   className?: string
 }
 
+type InputComponentProps = Pick<InputProps, 'inputWidth'>
+
 const Input = React.memo(
-  forwardRef<HTMLInputElement, IInputProps>(
+  forwardRef<HTMLInputElement, InputProps>(
     (
       {
         value,
@@ -47,7 +49,7 @@ const Input = React.memo(
   )
 )
 
-const InputComponent = styled.input<Pick<IInputProps, 'inputWidth'>>`
+const InputComponent = styled.input<InputComponentProps>`
   width: ${(props) => props.inputWidth};
   height: 50px;
   padding: 12px;


### PR DESCRIPTION
## 📋 풀리퀘스트 관련 코멘트 

1. Link 컴포넌트 사용시 DOM요소로 불필요한 props 전달 문제 해결
리액트 라우터의 Link 컴포넌트는 전달된 props를 내부적으로 DOM 요소에 적용합니다. 이로 인해 특정 props가 DOM 요소로 전달되면서 에러가 발생할 수 있습니다.
이모션의 css는 단순한 스타일만을 적용하기 때문에 이러한 에러가 발생하지 않습니다. 하지만 styled를 사용할 경우, props가 DOM 요소로 전달되는 과정에서 에러가 발생할 수 있습니다.
shouldForwardProp 함수를 사용하여 props가 DOM 요소로 전달되지 않도록 제어합니다.

2. button과 input 컴포넌트에 사용된 인터페이스 I로 표기된 부분을 제거했습니다.
3. button과 input의 타입을 정리했습니다.
4. 이거 내일 올릴려고 했는데 pr이 올라오네....요....^^ 승인 잘부탁드립니다...

close #55 


## 📸 스크린샷 (선택 사항)

![image](https://github.com/user-attachments/assets/55386205-e91d-4659-bc6b-fc705d3ed6b8)

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Link 컴포넌트에서 DOM 요소로 불필요한 props가 전달되는 문제를 shouldForwardProp 함수를 구현하여 수정합니다. Button, ButtonLink, Input 컴포넌트를 리팩토링하여 타입 정의를 개선하고 인터페이스 이름에서 'I' 접두사를 제거합니다.

버그 수정:
- shouldForwardProp 함수를 사용하여 Link 컴포넌트에서 DOM 요소로 불필요한 props가 전달되지 않도록 방지합니다.

개선 사항:
- Button, ButtonLink, Input 컴포넌트를 리팩토링하여 인터페이스 이름에서 'I' 접두사를 제거하고, 명확성과 일관성을 높이기 위해 타입 정의를 업데이트합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix the issue of unnecessary props being passed to DOM elements in the Link component by implementing the shouldForwardProp function. Refactor the Button, ButtonLink, and Input components to improve type definitions and remove the 'I' prefix from interface names.

Bug Fixes:
- Prevent unnecessary props from being passed to DOM elements in the Link component by using the shouldForwardProp function.

Enhancements:
- Refactor Button, ButtonLink, and Input components to remove the 'I' prefix from interface names and update type definitions for better clarity and consistency.

</details>

<!-- Generated by sourcery-ai[bot]: end summary -->