### PR TITLE
🔨 #68 로그인 한 사용자 프로필, 타사용자 프로필 접속 시 다르게 보이도록 수정

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -29,7 +29,6 @@ const router = createBrowserRouter([
       { path: PATH.PLAYLIST, element: <PlaylistPage /> },
       { path: PATH.USER_PROFILE, element: <ProfilePage /> },
       { path: PATH.CREATEPLAYLIST, element: <CreatePlaylistPage /> },
-      { path: PATH.PROFILE, element: <ProfilePage /> },
       { path: PATH.EDITPROFILE, element: <EditProfilePage /> },
       { path: PATH.FOLLOW, element: <FollowPage /> },
       { path: PATH.CHAT, element: <ChatPage /> },

--- a/src/api/playlist/getPlayList.ts
+++ b/src/api/playlist/getPlayList.ts
@@ -2,10 +2,15 @@ import { auth, db } from '@/firebase/firebaseConfig'
 import { collection, getDocs, getDoc, query, where, doc } from 'firebase/firestore'
 import { showplaylistProps, videoListProps } from '@/types/playlistType'
 import formatDate from '@/utils/formatDate'
+import { getUIDFromUserId } from '../profile/profileInfo'
 
 export const getPlayList = async (userId?: string) => {
   try {
-    const uid = userId || auth.currentUser?.uid
+    let uid = auth.currentUser?.uid
+
+    if (userId) {
+      uid = await getUIDFromUserId(userId)
+    }
 
     if (uid) {
       const playlistRef = collection(db, 'PLAYLISTS')

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -3,6 +3,9 @@ import { NavLink } from 'react-router-dom'
 import { PATH } from '@/constants/path'
 import { CircleUserRound, House, MessageCircleMore, Search, SquarePlus } from 'lucide-react'
 import { colors } from '@/constants/color'
+import useUserId from '@/hooks/useUserId'
+import { getUserIdFromUID } from '@/api/profile/profileInfo'
+import { useState, useEffect } from 'react'
 
 interface IconLinks {
   path: string
@@ -10,12 +13,30 @@ interface IconLinks {
 }
 
 const Navbar = () => {
+  const uid = useUserId()
+
+  const [userId, setUserId] = useState<string | null>(null)
+
+  useEffect(() => {
+    const fetchUserId = async () => {
+      if (uid) {
+        try {
+          const id = await getUserIdFromUID(uid)
+          setUserId(id)
+        } catch (error) {
+          console.error('Failed to fetch user ID:', error)
+        }
+      }
+    }
+    fetchUserId()
+  }, [uid])
+
   const menu: Array<IconLinks> = [
     { path: PATH.HOME, icon: <House /> },
     { path: PATH.SEARCH, icon: <Search /> },
     { path: PATH.CREATEPLAYLIST, icon: <SquarePlus /> },
     { path: PATH.CHAT, icon: <MessageCircleMore /> },
-    { path: PATH.PROFILE, icon: <CircleUserRound /> },
+    { path: `profile/${userId}`, icon: <CircleUserRound /> },
   ]
 
   return (

--- a/src/constants/path.ts
+++ b/src/constants/path.ts
@@ -6,7 +6,6 @@ export const PATH = {
   SIGNUP: '/login/signup',
   PLAYLIST: '/playlist/:playlistId',
   CREATEPLAYLIST: '/createplaylist',
-  PROFILE: '/profile',
   USER_PROFILE: '/profile/:userId',
   EDITPROFILE: '/profile/editprofile',
   FOLLOW: 'follow',

--- a/src/hooks/usePlaylistData.ts
+++ b/src/hooks/usePlaylistData.ts
@@ -1,31 +1,24 @@
 import { useEffect, useState } from 'react'
-import { auth } from '@/firebase/firebaseConfig'
-import { onAuthStateChanged } from 'firebase/auth'
 import { getPlayList } from '@/api/playlist/getPlayList'
 import { showplaylistProps } from '@/types/playlistType'
+import useUserId from './useUserId'
 
 export const usePlaylistData = (userId?: string) => {
+  const currentUser = useUserId(userId)
   const [playlistData, setPlayListData] = useState<showplaylistProps[]>([])
 
   useEffect(() => {
     const fetchPlayListData = async () => {
-      const data = await getPlayList(userId)
+      const data = await getPlayList(currentUser)
       if (data) {
         setPlayListData(data)
       }
     }
 
-    if (userId) {
+    if (currentUser) {
       fetchPlayListData()
-    } else {
-      const unsubscribe = onAuthStateChanged(auth, (user) => {
-        if (user) {
-          fetchPlayListData()
-        }
-      })
-      return () => unsubscribe()
     }
-  }, [userId])
+  }, [currentUser])
 
   return playlistData
 }

--- a/src/hooks/useUserData.ts
+++ b/src/hooks/useUserData.ts
@@ -1,10 +1,10 @@
 import { useState, useEffect } from 'react'
-import { auth } from '@/firebase/firebaseConfig'
-import { onAuthStateChanged } from 'firebase/auth'
 import { userInfo } from '@/api/profile/profileInfo'
 import Profile from '@/assets/profile_logo.jpg'
+import useUserId from './useUserId'
 
 export const useUserData = (userId?: string) => {
+  const currentUser = useUserId(userId)
   const [userData, setUserData] = useState({
     userName: '',
     userId: '',
@@ -18,7 +18,7 @@ export const useUserData = (userId?: string) => {
 
   useEffect(() => {
     const fetchUserData = async () => {
-      const data = await userInfo(userId)
+      const data = await userInfo(currentUser)
       if (data) {
         setUserData({
           userName: data?.userName || '사용자',
@@ -33,17 +33,10 @@ export const useUserData = (userId?: string) => {
       }
     }
 
-    if (userId) {
+    if (currentUser) {
       fetchUserData()
-    } else {
-      const unsubscribe = onAuthStateChanged(auth, (user) => {
-        if (user) {
-          fetchUserData()
-        }
-      })
-      return () => unsubscribe()
     }
-  }, [userId])
+  }, [currentUser])
 
   return userData
 }

--- a/src/hooks/useUserId.ts
+++ b/src/hooks/useUserId.ts
@@ -1,0 +1,21 @@
+import { useEffect, useState } from 'react'
+import { onAuthStateChanged } from 'firebase/auth'
+import { auth } from '@/firebase/firebaseConfig'
+
+const useUserId = (userId?: string) => {
+  const [currentUserId, setCurrentUserId] = useState<string | undefined>(userId)
+  useEffect(() => {
+    if (!userId) {
+      const unsubscribe = onAuthStateChanged(auth, (user) => {
+        if (user) {
+          setCurrentUserId(user.uid)
+        }
+      })
+      return () => unsubscribe()
+    }
+  }, [userId])
+
+  return currentUserId
+}
+
+export default useUserId

--- a/src/pages/ProfilePage.tsx
+++ b/src/pages/ProfilePage.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { Link, useParams } from 'react-router-dom'
 import { PATH } from '@/constants/path'
 import { fontSize, fontWeight } from '@/constants/font'
@@ -10,12 +10,15 @@ import Profile from '@/assets/profile_logo.jpg'
 import { useUserData } from '@/hooks/useUserData'
 import { usePlaylistData } from '@/hooks/usePlaylistData'
 import { filterPlaylist, showplaylistProps } from '@/types/playlistType'
+import useUserId from '@/hooks/useUserId'
+import { getUserIdFromUID } from '@/api/profile/profileInfo'
 
 const ProfilePage = () => {
   const { userId } = useParams<{ userId?: string }>()
+  const currentUser = useUserId()
   const userData = useUserData(userId)
   const playlistData = usePlaylistData(userId)
-  const isMyProfile = !userId || userId === userData.userId
+  const [isMyProfile, setIsMyProfile] = useState<boolean>(false)
   const [filter, setFilter] = useState<filterPlaylist>('all')
 
   const handleFilterChange = (newFilter: filterPlaylist) => {
@@ -46,6 +49,22 @@ const ProfilePage = () => {
       value: 'private' as filterPlaylist,
     },
   ]
+
+  useEffect(() => {
+    const fetchData = async () => {
+      if (currentUser && userData.userId) {
+        try {
+          const currentUserId = await getUserIdFromUID(currentUser)
+          if (currentUserId === userData.userId) {
+            setIsMyProfile(true)
+          }
+        } catch (error) {
+          console.error('Failed to fetch user ID:', error)
+        }
+      }
+    }
+    fetchData()
+  }, [currentUser, userData.userId])
 
   return (
     <Container>


### PR DESCRIPTION
## 📋 풀리퀘스트 관련 코멘트

userParams를 uid로 받지않고 userID로 받아서 사용자 프로필을 조회할 수 있도록 변경

아 플리 갯수가 3개인데 2개로 보이는건 하나는.. 비공개로 올라간겁니다~!

프로필 페이지 부분 라우팅도 변경사항 있습니다...


## 📸 스크린샷 (선택 사항)

로그인 한 사용자 프로필
![image](https://github.com/user-attachments/assets/02c6deed-70ee-4264-af8e-719bdcda3610)

타 사용자 프로필 조회
![image](https://github.com/user-attachments/assets/3a5a1a8e-c80b-4690-b5c1-da98956ab4f1)


