### PR TITLE
☠️ #111 유튜브 링크 중복으로 들어가는 현상 해결

### DIFF
--- a/src/hooks/usePLItem.ts
+++ b/src/hooks/usePLItem.ts
@@ -7,6 +7,13 @@ const usePLItem = () => {
   const [videoList, setVideoList] = useState<videoListProps[]>([])
   const [url, setUrl] = useState('')
 
+  const getVideoIdFromUrl = (url: string): string | null => {
+    const regex =
+      /(?:youtube\.com\/(?:[^/\n\s]+\/\S+\/|(?:v|e(?:mbed)?)\/|\S*?[?&]v=)|youtu\.be\/)([a-zA-Z0-9_-]{11})/
+    const match = url.match(regex)
+    return match ? match[1] : null
+  }
+
   const handleAddList = async () => {
     const isValidYoutubeUrl = (url: string): boolean => {
       const regex = /^(https?:\/\/)?(www\.youtube\.com|youtu\.?be)\/.+$/
@@ -14,11 +21,9 @@ const usePLItem = () => {
     }
 
     const isUniqueUrl = (url: string): boolean => {
-      if (videoList.length === 0) {
-        return true
-      }
-
-      return !videoList.some((video) => video.url === url)
+      const videoId = getVideoIdFromUrl(url)
+      if (!videoId) return false
+      return !videoList.some((video) => getVideoIdFromUrl(video.url) === videoId)
     }
 
     if (!isValidYoutubeUrl(url)) {
@@ -33,7 +38,7 @@ const usePLItem = () => {
     setIsValid(true)
 
     const youtubeKey = import.meta.env.VITE_YOUTUBE_API_KEY
-    const videoId = url.split('v=')[1]?.split('&')[0]
+    const videoId = getVideoIdFromUrl(url)
     const videoUrl = `https://www.googleapis.com/youtube/v3/videos?part=snippet&id=${videoId}&key=${youtubeKey}`
 
     try {


### PR DESCRIPTION
## 📋 풀리퀘스트 관련 코멘트

지영님이 해주셨는데 유튜브 링크 중복으로 들어가는 현상 해결했습니다.
유튜브 관련 유효성 체크 부분을 추가했습니다.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Sourcery에 의한 요약

비디오 ID를 추출하는 함수를 추가하고 이를 사용하여 URL의 고유성을 보장함으로써 중복된 YouTube 링크 문제를 해결합니다.

버그 수정:
- 고유한 비디오 ID를 확인하여 중복된 YouTube 링크가 추가되는 문제를 해결합니다.

개선 사항:
- YouTube URL에서 비디오 ID를 추출하는 유틸리티 함수를 추가하여 URL 검증 및 고유성 검사를 개선합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix the issue of duplicate YouTube links by adding a function to extract video IDs and using it to ensure URL uniqueness.

Bug Fixes:
- Resolve the issue of duplicate YouTube links being added by implementing a check for unique video IDs.

Enhancements:
- Add a utility function to extract the video ID from a YouTube URL for improved URL validation and uniqueness checks.

</details>

<!-- Generated by sourcery-ai[bot]: end summary -->