### PR TITLE
☠️ #113 댓글 삭제 버튼 안보이는 이슈 해결, 기능 작동 확인

### DIFF
--- a/src/components/comments/CommentCard.tsx
+++ b/src/components/comments/CommentCard.tsx
@@ -1,12 +1,12 @@
 import React, { useState } from 'react'
 import styled from '@emotion/styled'
 import { Trash2 } from 'lucide-react'
-import { auth } from '@/firebase/firebaseConfig'
 import { CommentType } from '@/types/commentType'
 import { colors } from '@/constants/color'
 import { Link } from 'react-router-dom'
 import deleteComment from '@/service/comment/deleteComment'
 import NPProfile from '@/assets/np_logo.svg'
+import { useIsMyProfile } from '@/hooks/useIsMyProfile'
 
 interface CommentCardProps {
   comment: CommentType
@@ -16,8 +16,7 @@ interface CommentCardProps {
 
 const CommentCard: React.FC<CommentCardProps> = ({ comment, playlistId, onCommentDeleted }) => {
   const [isExpanded, setIsExpanded] = useState(false)
-
-  const isCurrentUserComment = auth.currentUser?.uid === comment.userId
+  const { data: isCurrentUserComment } = useIsMyProfile(comment.userId)
 
   const handleDeleteComment = async () => {
     if (window.confirm('삭제하시겠습니까?')) {


### PR DESCRIPTION
## 📋 풀리퀘스트 관련 코멘트

comment.userId와 현재 로그인한 유저의 uid를 비교하고 있어 iscurrentComment가 false 상태를 반환하고 있었습니다
그래서 삭제 버튼이 렌더링이 되지않는 이슈를 확인했고 useIsMyProfile 훅을 활용해서 이슈를 해결해두었습니다~!~!


## 📸 스크린샷 (선택 사항)

<!-- 수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부해 주세요.--!>
<br/>

<!-- Generated by sourcery-ai[bot]: start summary -->

## Sourcery에 의한 요약

댓글 삭제 버튼이 나타나지 않는 문제를 해결하기 위해 직접적인 사용자 ID 비교를 useIsMyProfile 훅으로 대체하여 댓글 소유권을 확인합니다.

버그 수정:
- useIsMyProfile 훅을 사용하여 현재 사용자가 댓글 소유자인지 올바르게 판단함으로써 댓글 삭제 버튼이 보이지 않는 문제를 수정합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Resolve the issue of the comment delete button not appearing by replacing the direct user ID comparison with the useIsMyProfile hook to verify comment ownership.

Bug Fixes:
- Fix the issue where the delete button for comments was not visible by using the useIsMyProfile hook to correctly determine if the current user is the comment owner.

</details>

<!-- Generated by sourcery-ai[bot]: end summary -->