### PR TITLE
☠️ #115 비공개 플리로 업로드 된 태그는 검색 안되도록 수정

### DIFF
--- a/src/components/search/SearchSuccess.tsx
+++ b/src/components/search/SearchSuccess.tsx
@@ -12,7 +12,7 @@ const SearchSuccess = ({
 }) => (
   <Container>
     <h3 className="success-tag">
-      검색 태그 :{!previousSearchTag.startsWith('#') ? `#${previousSearchTag}` : previousSearchTag}
+      {!previousSearchTag.startsWith('#') ? `#${previousSearchTag}` : previousSearchTag}
     </h3>
     <div className="search-success">
       {playlists.map((playlist) => (

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -15,7 +15,10 @@ const SearchPage = () => {
   const [hasSearched, setHasSearched] = useState(false)
 
   const handleSearch = async () => {
-    if (!searchTag.trim()) return
+    if (!searchTag.trim()) {
+      setHasSearched(false)
+      return
+    }
 
     const formattedSearchTag = !searchTag.startsWith('#') ? '#' + searchTag : searchTag
     const results = await SearchTag(formattedSearchTag)

--- a/src/service/search/getRecommendTags.ts
+++ b/src/service/search/getRecommendTags.ts
@@ -15,7 +15,7 @@ const getRecommendTags = async (): Promise<string[]> => {
 
     querySnapshot.forEach((doc) => {
       const data = doc.data()
-      if (data.tags && Array.isArray(data.tags)) {
+      if (data.isPrivate === false && data.tags && Array.isArray(data.tags)) {
         allTags = allTags.concat(data.tags)
       }
     })

--- a/src/service/search/searchTag.ts
+++ b/src/service/search/searchTag.ts
@@ -11,7 +11,11 @@ export interface Playlist {
 export const SearchTag = async (tag: string): Promise<Playlist[]> => {
   const formattedTag = `${tag.trim()}`
   const playlistsRef = collection(db, 'PLAYLISTS')
-  const q = query(playlistsRef, where('tags', 'array-contains', formattedTag))
+  const q = query(
+    playlistsRef,
+    where('tags', 'array-contains', formattedTag),
+    where('isPrivate', '==', false)
+  )
 
   const querySnapshot = await getDocs(q)
   const results: Playlist[] = []


### PR DESCRIPTION
## 📋 풀리퀘스트 관련 코멘트

- 비공개로 업로드된 플리는 검색될 수 없도록 수정, 추천 태그에서도 뜨지 않도록 수정
- 검색 후 다시 추천검색어를 보고 싶은 경우 빈 입력란에서 검색 버튼 클릭시 볼 수 있도록 수정

## 📸 스크린샷 (선택 사항)

<!-- 수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부해 주세요.--!>
<br/>

<!-- Generated by sourcery-ai[bot]: start summary -->

## Sourcery에 의한 요약

검색 기능을 수정하여 검색 결과와 추천 태그에서 비공개 재생목록을 제외합니다. 사용자가 빈 입력으로 검색 버튼을 클릭할 때 추천 검색어를 볼 수 있도록 하여 검색 경험을 향상시킵니다.

버그 수정:
- 비공개 재생목록이 검색 결과와 추천 태그에 나타나지 않도록 방지합니다.

기능 향상:
- 빈 입력 필드로 검색 버튼을 클릭하여 사용자가 추천 검색어를 볼 수 있도록 허용합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Modify the search functionality to exclude private playlists from search results and recommended tags. Enhance the search experience by enabling users to view recommended search terms when the search button is clicked with an empty input.

Bug Fixes:
- Prevent private playlists from appearing in search results and recommended tags.

Enhancements:
- Allow users to view recommended search terms by clicking the search button with an empty input field.

</details>

<!-- Generated by sourcery-ai[bot]: end summary -->