### PR TITLE
☠️ #115 플리 최신순으로 나열되도록 정렬 추가

### DIFF
--- a/src/components/playlist/MusicItem.tsx
+++ b/src/components/playlist/MusicItem.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled'
-import { showplaylistProps, videoListProps } from '@/types/playlistType'
+import { BasicVideoProps, showplaylistProps } from '@/types/playlistType'
 import { Trash2 } from 'lucide-react'
 import { colors } from '@/constants/color'
 import { fontSize } from '@/constants/font'
@@ -7,12 +7,12 @@ import PlaylistThumbnails from '@/components/search/PlaylistThumbnails'
 import { Link } from 'react-router-dom'
 
 interface MusicItemProps {
-  videoList: videoListProps[] | showplaylistProps[]
+  videoList: BasicVideoProps[] | showplaylistProps[]
   onItemDelete?: (id: number) => void | ''
   variant: 'profilePL' | 'createPL'
 }
 
-const isVideoListProps = (item: showplaylistProps | videoListProps): item is videoListProps => {
+const isVideoListProps = (item: showplaylistProps | BasicVideoProps): item is BasicVideoProps => {
   return 'channelTitle' in item
 }
 
@@ -21,7 +21,7 @@ const MusicItem = ({ videoList, onItemDelete, variant }: MusicItemProps) => {
     <Container variant={variant}>
       {videoList.map((item, idx) => (
         <div key={idx} className="item-video">
-          {variant === 'profilePL' ? (
+          {variant === 'profilePL' && 'playlistId' in item ? (
             <Link to={`/playlist/${item.playlistId}`} className="thumbnail-list">
               <div className="thumbnail">
                 <PlaylistThumbnails playlistId={item.playlistId || ''} />

--- a/src/components/search/PlaylistThumbnails.tsx
+++ b/src/components/search/PlaylistThumbnails.tsx
@@ -1,10 +1,10 @@
 import { useState, useEffect } from 'react'
-import { videoListProps } from '@/types/playlistType'
+import { ExtendedVideoProps } from '@/types/playlistType'
 import styled from '@emotion/styled'
 import getUserPlaylistDetails from '@/service/playlist/getUserPlaylistDetails'
 
 const PlaylistThumbnails = ({ playlistId }: { playlistId: string }) => {
-  const [videos, setVideos] = useState<videoListProps[]>([])
+  const [videos, setVideos] = useState<ExtendedVideoProps[]>([])
 
   useEffect(() => {
     const fetchThumbnails = async () => {

--- a/src/hooks/usePLItem.ts
+++ b/src/hooks/usePLItem.ts
@@ -1,10 +1,10 @@
+import { BasicVideoProps } from '@/types/playlistType'
 import { useState } from 'react'
-import { videoListProps } from '@/types/playlistType'
 
 const usePLItem = () => {
   const [isValid, setIsValid] = useState(true)
   const [validType, setValidType] = useState('')
-  const [videoList, setVideoList] = useState<videoListProps[]>([])
+  const [videoList, setVideoList] = useState<BasicVideoProps[]>([])
   const [url, setUrl] = useState('')
 
   const getVideoIdFromUrl = (url: string): string | null => {
@@ -52,7 +52,7 @@ const usePLItem = () => {
           url: `https://www.youtube.com/watch?v=${videoId}`,
           thumbnail: data.items[0].snippet.thumbnails.medium.url,
         }
-        setVideoList((prev: videoListProps[]) => [...prev, videoData])
+        setVideoList((prev: BasicVideoProps[]) => [...prev, videoData])
         setUrl('')
       }
     } catch (error) {
@@ -61,7 +61,7 @@ const usePLItem = () => {
   }
 
   const handleDelete = (id: number) => {
-    setVideoList((prev: videoListProps[]) => prev.filter((_, index) => index !== id))
+    setVideoList((prev: BasicVideoProps[]) => prev.filter((_, index) => index !== id))
   }
 
   return {

--- a/src/hooks/usePlaylistDetail.ts
+++ b/src/hooks/usePlaylistDetail.ts
@@ -1,10 +1,10 @@
 import { useEffect, useState } from 'react'
-import { videoListProps } from '@/types/playlistType'
+import { ExtendedVideoProps } from '@/types/playlistType'
 import getUserPlaylistDetails from '@/service/playlist/getUserPlaylistDetails'
 
 export const usePlaylistdetail = (playlistId?: string) => {
-  const [videos, setVideos] = useState<videoListProps[]>([])
-  const [selectedVideo, setSelectedVideo] = useState<videoListProps>()
+  const [videos, setVideos] = useState<ExtendedVideoProps[]>([])
+  const [selectedVideo, setSelectedVideo] = useState<ExtendedVideoProps>()
   useEffect(() => {
     const fetchPlaylistDetails = async () => {
       if (playlistId) {

--- a/src/pages/ProfilePage.tsx
+++ b/src/pages/ProfilePage.tsx
@@ -37,14 +37,9 @@ const ProfilePage = () => {
     private: (playlistData) => !!playlistData.isPrivate,
   }
 
-  const filteredLists = playlistData
-    .filter((playlistData: showplaylistProps) => {
-      return !isMyProfile && playlistData.isPrivate ? false : filteredMap[filter](playlistData)
-    })
-    .sort(
-      (a: showplaylistProps, b: showplaylistProps) =>
-        new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
-    )
+  const filteredLists = playlistData.filter((playlistData: showplaylistProps) => {
+    return !isMyProfile && playlistData.isPrivate ? false : filteredMap[filter](playlistData)
+  })
 
   const filterBtns = [
     {

--- a/src/pages/ProfilePage.tsx
+++ b/src/pages/ProfilePage.tsx
@@ -37,9 +37,14 @@ const ProfilePage = () => {
     private: (playlistData) => !!playlistData.isPrivate,
   }
 
-  const filteredLists = playlistData.filter((playlistData: showplaylistProps) => {
-    return !isMyProfile && playlistData.isPrivate ? false : filteredMap[filter](playlistData)
-  })
+  const filteredLists = playlistData
+    .filter((playlistData: showplaylistProps) => {
+      return !isMyProfile && playlistData.isPrivate ? false : filteredMap[filter](playlistData)
+    })
+    .sort(
+      (a: showplaylistProps, b: showplaylistProps) =>
+        new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+    )
 
   const filterBtns = [
     {
@@ -123,7 +128,7 @@ const ProfilePage = () => {
           플레이리스트 모두 보기
         </Button>
       )}
-      {isOpen && (
+      {filteredLists.length > 4 && isOpen && (
         <Button variant="text" onClick={handleToggleOpen}>
           플레이리스트 모두 접기
         </Button>

--- a/src/pages/ProfilePage.tsx
+++ b/src/pages/ProfilePage.tsx
@@ -37,9 +37,14 @@ const ProfilePage = () => {
     private: (playlistData) => !!playlistData.isPrivate,
   }
 
-  const filteredLists = playlistData.filter((playlistData: showplaylistProps) => {
-    return !isMyProfile && playlistData.isPrivate ? false : filteredMap[filter](playlistData)
-  })
+  const filteredLists = playlistData
+    .filter((playlistData: showplaylistProps) => {
+      return !isMyProfile && playlistData.isPrivate ? false : filteredMap[filter](playlistData)
+    })
+    .sort(
+      (a: showplaylistProps, b: showplaylistProps) =>
+        new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+    )
 
   const filterBtns = [
     {

--- a/src/service/playlist/createNewPlaylist.ts
+++ b/src/service/playlist/createNewPlaylist.ts
@@ -1,12 +1,12 @@
 import { db } from '@/firebase/firebaseConfig'
-import { videoListProps } from '@/types/playlistType'
+import { BasicVideoProps } from '@/types/playlistType'
 import { getLoggedInUserUID } from '@/utils/userDataUtils'
 import { addDoc, collection, getDoc, doc } from 'firebase/firestore'
 
 const createNewPlaylist = async (
   title: string,
   tags: string[],
-  videoList: videoListProps[],
+  videoList: BasicVideoProps[],
   isPrivate: boolean
 ) => {
   try {

--- a/src/types/playlistType.d.ts
+++ b/src/types/playlistType.d.ts
@@ -1,3 +1,19 @@
+export interface BasicVideoProps {
+  title: string
+  channelTitle: string
+  url: string
+  thumbnail: string
+}
+
+export interface ExtendedVideoProps extends BasicVideoProps {
+  author: string
+  authorImg?: string
+  uploadDate: string
+  tags: string[]
+  playlistTitle?: string
+  likes?: number
+}
+
 export interface showplaylistProps {
   playlistId: string
   title: string
@@ -6,16 +22,6 @@ export interface showplaylistProps {
   createdAt: string
 }
 
-export interface videoListProps extends showplaylistProps {
-  channelTitle: string
-  id?: Key | null | undefined
-  url: string
-  uploadDate?: string
-  author?: string
-  authorImg?: string
-  tags?: string[]
-  playlistTitle?: string
-  likes?: number
-}
+export interface videoListProps extends showplaylistProps, ExtendedVideoProps {}
 
 export type filterPlaylist = 'all' | 'public' | 'private'


### PR DESCRIPTION
## 📋 풀리퀘스트 관련 코멘트

프로필에서 플리 등록 시 최신순으로 나열되도록 수정해뒀습니다~!
<br/>

## 📸 스크린샷 (선택 사항)

<!-- 수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부해 주세요.--!>
<br/>

<!-- Generated by sourcery-ai[bot]: start summary -->

## Sourcery에 의한 요약

프로필 페이지를 개선하여 생성 날짜를 기준으로 플레이리스트를 내림차순으로 정렬하여 가장 최근의 플레이리스트가 먼저 표시되도록 합니다.

개선 사항:
- 프로필 페이지에서 가장 최근의 플레이리스트가 먼저 표시되도록 생성 날짜를 기준으로 플레이리스트를 내림차순으로 정렬합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhance the profile page by sorting playlists in descending order based on their creation date, ensuring the most recent playlists are displayed first.

Enhancements:
- Sort playlists by creation date in descending order to display the most recent ones first on the profile page.

</details>

<!-- Generated by sourcery-ai[bot]: end summary -->