### PR TITLE
☠️ #124 프로필 페이지 플리 이미지 그리드 정사각형으로 렌더링 되도록 수정

### DIFF
--- a/src/components/common/ImageGrid.tsx
+++ b/src/components/common/ImageGrid.tsx
@@ -9,7 +9,7 @@ interface ImageGridProps {
   size?: ImageGridSize
 }
 
-const ImageGrid: React.FC<ImageGridProps> = ({ thumbnails, size = 'small' }) => {
+const ImageGrid: React.FC<ImageGridProps> = ({ thumbnails, size = 'large' }) => {
   const displayThumbnails = [...thumbnails]
   if (thumbnails.length === 3) {
     displayThumbnails.push(defaultThumbnail)
@@ -29,8 +29,8 @@ const ImageGrid: React.FC<ImageGridProps> = ({ thumbnails, size = 'small' }) => 
 export default ImageGrid
 
 const sizeStyles = {
-  small: '70px',
-  large: '52px',
+  large: '70px',
+  small: '52px',
 }
 
 const Container = styled.div<{ count: number; size: ImageGridSize }>`

--- a/src/components/playlist/MusicItem.tsx
+++ b/src/components/playlist/MusicItem.tsx
@@ -27,7 +27,7 @@ const MusicItem = ({ videoList, onItemDelete, variant }: MusicItemProps) => {
             {variant === 'profilePL' && 'playlistId' in item ? (
               <Link to={`/playlist/${item.playlistId}`} className="thumbnail-list">
                 <div className="thumbnail">
-                  <ImageGrid thumbnails={thumbnails} />
+                  <ImageGrid thumbnails={thumbnails} size="small" />
                 </div>
                 <div className="text-content">
                   <p>{item.title}</p>


### PR DESCRIPTION
## 📋 풀리퀘스트 관련 코멘트

프로필 페이지 플리 이미지에 활용되는 컴포넌트 size 타입 수정

## 📸 스크린샷 (선택 사항)

<!-- Generated by sourcery-ai[bot]: start summary -->

## Sourcery에 의한 요약

ImageGrid 컴포넌트를 조정하여 프로필 페이지 재생목록 이미지를 정사각형으로 렌더링하도록 기본 크기를 수정하고 크기 매핑을 업데이트합니다.

버그 수정:
- ImageGrid 컴포넌트에서 기본 크기를 조정하여 프로필 페이지 재생목록 이미지가 정사각형으로 표시되도록 렌더링 문제를 해결합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust the ImageGrid component to render profile page playlist images as squares by modifying the default size and updating the size mapping.

Bug Fixes:
- Fix the rendering of profile page playlist images to ensure they are displayed as squares by adjusting the default size in the ImageGrid component.

</details>

<!-- Generated by sourcery-ai[bot]: end summary -->