### PR TITLE
[refactor] 프로필 페이지 pr 리뷰 참고하여 수정

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -26,7 +26,7 @@ module.exports = {
     'react/react-in-jsx-scope': 'off',
     'react/prop-types': 'off',
     'no-console': 'warn',
-    'no-unused-vars': 'warn',
+    '@typescript-eslint/no-unused-vars': 'error',
     'no-console': ['warn', { allow: ['warn', 'error'] }],
     '@tanstack/query/exhaustive-deps': 'error',
     '@tanstack/query/stable-query-client': 'error',

--- a/src/pages/ProfilePage.tsx
+++ b/src/pages/ProfilePage.tsx
@@ -7,7 +7,7 @@ import { colors } from '@/styles/colors'
 import NPProfile from '@/assets/np_logo.svg'
 import { useUserData } from '@/hooks/useUserData'
 import { usePlaylistData } from '@/hooks/usePlaylistData'
-import { filterPlaylist, PlaylistBaseProps } from '@/types/playlistType'
+import type { filterPlaylist, PlaylistBaseProps } from '@/types/playlistType'
 import MusicItem from '@/components/playlist/MusicItem'
 import { getLoggedInUserUID } from '@/utils/userDataUtils'
 import { useFollowButton } from '@/hooks/useFollowStatus'
@@ -47,7 +47,7 @@ const ProfilePage = () => {
   }
 
   const filteredMap: Record<filterPlaylist, (playlistData: PlaylistBaseProps) => boolean> = {
-    all: () => true,
+    all: () => true as boolean,
     public: (playlistData) => !playlistData.isPrivate,
     private: (playlistData) => !!playlistData.isPrivate,
   }


### PR DESCRIPTION
## 📋 풀리퀘스트 관련 코멘트

pr코드리뷰 참고하여 프로필 페이지 import type으로 관리하도록 수정, all 타입 수정

<!-- Generated by sourcery-ai[bot]: start summary -->

## Sourcery에 의한 요약

'모두' 필터에 대한 타입 관리를 업데이트하고 사용되지 않는 변수에 대한 더 엄격한 규칙을 적용하기 위해 ESLint 구성을 조정하여 ProfilePage 컴포넌트를 리팩터링합니다.

개선 사항:
- '@typescript-eslint/no-unused-vars'를 사용하여 사용되지 않는 변수에 대한 ESLint 규칙을 경고에서 오류로 변경합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor the ProfilePage component by updating type management for the 'all' filter and adjust ESLint configuration to enforce stricter rules on unused variables.

Enhancements:
- Change ESLint rule for unused variables from a warning to an error using '@typescript-eslint/no-unused-vars'.

</details>

<!-- Generated by sourcery-ai[bot]: end summary -->